### PR TITLE
Feature/exempt recent images

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,11 @@ The payload is expected to be JSON with the following fields:
   the duration will not be deleted. If unspecified, the default is no grace
   period (all untagged image refs are deleted).
 
-- `allow_tagged` - If set to true, will check all images includding tagged.
+- `allow_tagged` - If set to true, will check all images including tagged.
   If unspecified, the default will only delete untagged images.
 
+- `keep` - If an integer is provided, it will always keep that minimum number 
+  of images. Note that it will not consider images inside the `grace` duration.
 
 ## FAQ
 

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -44,7 +44,7 @@ func NewCleaner(auther gcrauthn.Authenticator, c int) (*Cleaner, error) {
 }
 
 // Clean deletes old images from GCR that are untagged and older than "since".
-func (c *Cleaner) Clean(repo string, since time.Time, allow_tagged bool) ([]string, error) {
+func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)
@@ -64,7 +64,7 @@ func (c *Cleaner) Clean(repo string, since time.Time, allow_tagged bool) ([]stri
 	var errsLock sync.RWMutex
 
 	for k, m := range tags.Manifests {
-		if c.shouldDelete(m, since, allow_tagged) {
+		if c.shouldDelete(m, since, allowTagged) {
 			// Deletes all tags before deleting the image
 			for _, tag := range m.Tags {
 				tagged := repo + ":" + tag
@@ -137,6 +137,6 @@ func (c *Cleaner) deleteOne(ref string) error {
 
 // shouldDelete returns true if the manifest has no tags and is before the
 // requested time.
-func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allow_tag bool) bool {
-	return (allow_tag || len(m.Tags) == 0) && m.Uploaded.UTC().Before(since)
+func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool) bool {
+	return (allowTag || len(m.Tags) == 0) && m.Uploaded.UTC().Before(since)
 }

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -129,11 +129,11 @@ func (s *Server) clean(r io.ReadCloser) ([]string, int, error) {
 	}
 
 	since := time.Now().UTC().Add(time.Duration(p.Grace))
-	allow_tagged := p.AllowTagged
+	allowTagged := p.AllowTagged
 
 	log.Printf("deleting refs for %s since %s\n", repo, since)
 
-	deleted, err := s.cleaner.Clean(repo, since, allow_tagged)
+	deleted, err := s.cleaner.Clean(repo, since, allowTagged)
 	if err != nil {
 		return nil, 400, fmt.Errorf("failed to clean: %w", err)
 	}

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -130,10 +130,11 @@ func (s *Server) clean(r io.ReadCloser) ([]string, int, error) {
 
 	since := time.Now().UTC().Add(time.Duration(p.Grace))
 	allowTagged := p.AllowTagged
+	keep := p.Keep
 
 	log.Printf("deleting refs for %s since %s\n", repo, since)
 
-	deleted, err := s.cleaner.Clean(repo, since, allowTagged)
+	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep)
 	if err != nil {
 		return nil, 400, fmt.Errorf("failed to clean: %w", err)
 	}
@@ -171,6 +172,9 @@ type Payload struct {
 	// AllowTagged is a Boolean value determine if tagged images are allowed
 	// to be deleted.
 	AllowTagged bool `json:"allow_tagged"`
+
+	// Keep is an Integer if the number of images to keep at minimum in the repo
+	Keep int `json:"keep"`
 }
 
 type pubsubMessage struct {


### PR DESCRIPTION
Fixes #12 
This adds a new optional parameter to keep a minimum number of images from the repository.
I also renamed the `allow_tagged` to respect golang camel casing.