### PR TITLE
Return error on invalid duration

### DIFF
--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -213,7 +213,7 @@ func (d *duration) UnmarshalJSON(b []byte) error {
 	case string:
 		s, err := time.ParseDuration(val)
 		if err != nil {
-			return nil
+			return err
 		}
 		*d = duration(s)
 		return nil


### PR DESCRIPTION
A request with an invalid duration string should be rejected.