### PR TITLE
Feature/keep tags based on pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ The payload is expected to be JSON with the following fields:
 - `keep` - If an integer is provided, it will always keep that minimum number
   of images. Note that it will not consider images inside the `grace` duration.
 
+- `tag_prefix` - Used for tag prefix limitation, requires `allow_tagged` must be true.
+  For example: use "dev" to limit cleaning only on the tags with prefix is "dev". The default
+  is no filtering.
+
 ## Running locally
 
 In addition to the server, you can also run GCR Cleaner locally for one-off tasks using `cmd/gcr-cleaner-cli`:

--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ The payload is expected to be JSON with the following fields:
 - `keep` - If an integer is provided, it will always keep that minimum number
   of images. Note that it will not consider images inside the `grace` duration.
 
-- `tag_prefix` - Used for tag prefix limitation, requires `allow_tagged` must be true.
-  For example: use "dev" to limit cleaning only on the tags with prefix is "dev". The default
+- `tag_filter` - Used for tags regexp definition to define pattern to clean,
+  requires `allow_tagged` must be true. For example: use `-tag-filter "^dev.+$"`
+  to limit cleaning only on the tags with begining with is `dev`. The default
   is no filtering.
 
 ## Running locally

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The payload is expected to be JSON with the following fields:
 - `tag_filter` - Used for tags regexp definition to define pattern to clean,
   requires `allow_tagged` must be true. For example: use `-tag-filter "^dev.+$"`
   to limit cleaning only on the tags with begining with is `dev`. The default
-  is no filtering.
+  is no filtering. The regular expression is parsed according to the [Go regexp package syntax](https://golang.org/pkg/regexp/syntax/).
 
 ## Running locally
 

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -60,7 +60,7 @@ func realMain() error {
 
 	tagFilterRegexp, err := regexp.Compile(*tagFilterPtr)
 	if err != nil {
-		return fmt.Errorf("failed to parse -tag-filter")
+		return fmt.Errorf("failed to parse -tag-filter: %w", err)
 	}
 
 	// Try to find the "best" authentication.

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -36,6 +36,7 @@ var (
 	gracePtr       = flag.Duration("grace", 0, "Grace period")
 	allowTaggedPtr = flag.Bool("allow-tagged", false, "Delete tagged images")
 	keepPtr        = flag.Int("keep", 0, "Minimum to keep")
+	tagPrefixPtr   = flag.String("tag-prefix", "", "Tag prefix to clean")
 )
 
 func main() {
@@ -52,6 +53,9 @@ func realMain() error {
 		return fmt.Errorf("missing -repo")
 	}
 
+	if *allowTaggedPtr == false && *tagPrefixPtr != "" {
+		return fmt.Errorf("-allow-tagged must be true when -tag-prefix is declared")
+	}
 	// Try to find the "best" authentication.
 	var auther gcrauthn.Authenticator
 	if *tokenPtr != "" {
@@ -80,7 +84,7 @@ func realMain() error {
 
 	// Do the deletion.
 	fmt.Fprintf(stdout, "%s: deleting refs since %s\n", *repoPtr, since)
-	deleted, err := cleaner.Clean(*repoPtr, since, *allowTaggedPtr, *keepPtr)
+	deleted, err := cleaner.Clean(*repoPtr, since, *allowTaggedPtr, *keepPtr, *tagPrefixPtr)
 	if err != nil {
 		return err
 	}

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -91,7 +91,7 @@ func realMain() error {
 
 	// Do the deletion.
 	fmt.Fprintf(stdout, "%s: deleting refs since %s\n", *repoPtr, since)
-	deleted, err := cleaner.Clean(*repoPtr, since, *allowTaggedPtr, *keepPtr, *tagFilterRegexp)
+	deleted, err := cleaner.Clean(*repoPtr, since, *allowTaggedPtr, *keepPtr, tagFilterRegexp)
 	if err != nil {
 		return err
 	}

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -18,6 +18,7 @@ package gcrcleaner
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -47,7 +48,7 @@ func NewCleaner(auther gcrauthn.Authenticator, c int) (*Cleaner, error) {
 
 // Clean deletes old images from GCR that are (un)tagged and older than "since" and
 // higher than the "keep" amount.
-func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int) ([]string, error) {
+func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int, tagPrefix string) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)
@@ -78,7 +79,7 @@ func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int
 	})
 
 	for _, m := range manifests {
-		if c.shouldDelete(m.Info, since, allowTagged) {
+		if c.shouldDelete(m.Info, since, allowTagged, tagPrefix) {
 			// Keep a certain amount of images
 			if keepCount < keep {
 				keepCount++
@@ -160,6 +161,7 @@ func (c *Cleaner) deleteOne(ref gcrname.Reference) error {
 
 // shouldDelete returns true if the manifest has no tags or allows deletion of tagged images
 // and is before the requested time.
-func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool) bool {
-	return (allowTag || len(m.Tags) == 0) && m.Uploaded.UTC().Before(since)
+func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool, tagPrefix string) bool {
+	r, _ := regexp.Compile("^" + tagPrefix + ".*$")
+	return ((allowTag && r.MatchString(m.Tags[0])) || len(m.Tags) == 0) && m.Uploaded.UTC().Before(since)
 }

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -48,7 +48,7 @@ func NewCleaner(auther gcrauthn.Authenticator, c int) (*Cleaner, error) {
 
 // Clean deletes old images from GCR that are (un)tagged and older than "since" and
 // higher than the "keep" amount.
-func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int, tagFilterRegexp regexp.Regexp) ([]string, error) {
+func (c *Cleaner) Clean(repo string, since time.Time, allowTagged bool, keep int, tagFilterRegexp *regexp.Regexp) ([]string, error) {
 	gcrrepo, err := gcrname.NewRepository(repo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repo %s: %w", repo, err)
@@ -161,6 +161,6 @@ func (c *Cleaner) deleteOne(ref gcrname.Reference) error {
 
 // shouldDelete returns true if the manifest has no tags or allows deletion of tagged images
 // and is before the requested time.
-func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool, tagFilterRegexp regexp.Regexp) bool {
+func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool, tagFilterRegexp *regexp.Regexp) bool {
 	return ((allowTag && tagFilterRegexp.MatchString(m.Tags[0])) || len(m.Tags) == 0) && m.Uploaded.UTC().Before(since)
 }

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -131,10 +131,11 @@ func (s *Server) clean(r io.ReadCloser) ([]string, int, error) {
 	since := time.Now().UTC().Add(sub)
 	allowTagged := p.AllowTagged
 	keep := p.Keep
+	tagPrefix := p.TagPrefix
 
 	log.Printf("deleting refs for %s since %s\n", repo, since)
 
-	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep)
+	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, tagPrefix)
 	if err != nil {
 		return nil, 400, fmt.Errorf("failed to clean: %w", err)
 	}
@@ -175,6 +176,9 @@ type Payload struct {
 
 	// Keep is the minimum number of images to keep.
 	Keep int `json:"keep"`
+
+	// TagPrefix is trigger only allow removing on tags with prefix
+	TagPrefix string `json:"tag_prefix"`
 }
 
 type pubsubMessage struct {

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"regexp"
 	"time"
 )
 
@@ -131,11 +132,14 @@ func (s *Server) clean(r io.ReadCloser) ([]string, int, error) {
 	since := time.Now().UTC().Add(sub)
 	allowTagged := p.AllowTagged
 	keep := p.Keep
-	tagPrefix := p.TagPrefix
+	tagFilterRegexp, err := regexp.Compile(p.TagFilter)
+	if err != nil {
+		return nil, 500, fmt.Errorf("failed to parse tag_filter: %w", err)
+	}
 
 	log.Printf("deleting refs for %s since %s\n", repo, since)
 
-	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, tagPrefix)
+	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, *tagFilterRegexp)
 	if err != nil {
 		return nil, 400, fmt.Errorf("failed to clean: %w", err)
 	}
@@ -177,8 +181,8 @@ type Payload struct {
 	// Keep is the minimum number of images to keep.
 	Keep int `json:"keep"`
 
-	// TagPrefix is trigger only allow removing on tags with prefix
-	TagPrefix string `json:"tag_prefix"`
+	// TagFilter is trigger only allow removing on tags with prefix
+	TagFilter string `json:"tag_filter"`
 }
 
 type pubsubMessage struct {

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -139,7 +139,7 @@ func (s *Server) clean(r io.ReadCloser) ([]string, int, error) {
 
 	log.Printf("deleting refs for %s since %s\n", repo, since)
 
-	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, *tagFilterRegexp)
+	deleted, err := s.cleaner.Clean(repo, since, allowTagged, keep, tagFilterRegexp)
 	if err != nil {
 		return nil, 400, fmt.Errorf("failed to clean: %w", err)
 	}

--- a/pkg/gcrcleaner/server.go
+++ b/pkg/gcrcleaner/server.go
@@ -181,7 +181,7 @@ type Payload struct {
 	// Keep is the minimum number of images to keep.
 	Keep int `json:"keep"`
 
-	// TagFilter is trigger only allow removing on tags with prefix
+	// TagFilter is the tags pattern to be allowed removing
 	TagFilter string `json:"tag_filter"`
 }
 


### PR DESCRIPTION


According to the idea from this [issue](https://github.com/sethvargo/gcr-cleaner/issues/16), I have added a tag filtering feature which helps us on filtering only tags with the declared prefix (tags begin with -tag-prefix definition).

**Notice** 

- This feature is just under a heavy construction, do not use it for your production until it's merged to master branch. 
- For every digest, I have only checked for the first tag in the tags array. My thought it's good enough for determining a digest can be removed or not.
- Feel free to correct me.


**Example**
Let's look at the example below

1. *What tags I have?*

    ```sh
    asia.gcr.io/foo/bar:staging-build-64
    asia.gcr.io/foo/bar:staging-build-63
    asia.gcr.io/foo/bar:staging-build-62
    asia.gcr.io/foo/bar:staging-build-61
    asia.gcr.io/foo/bar:staging-build-60
    asia.gcr.io/foo/bar:staging-build-59
    asia.gcr.io/foo/bar:staging-build-58
    asia.gcr.io/foo/bar:staging-build-55
    asia.gcr.io/foo/bar:staging-build-54
    asia.gcr.io/foo/bar:staging-build-52
    asia.gcr.io/foo/bar:master-build-38
    asia.gcr.io/foo/bar:master-build-37
    asia.gcr.io/foo/bar:master-build-36
    asia.gcr.io/foo/bar:master-build-35
    asia.gcr.io/foo/bar:master-build-34
    asia.gcr.io/foo/bar:master-build-33
    asia.gcr.io/foo/bar:master-build-32
    asia.gcr.io/foo/bar:master-build-31
    asia.gcr.io/foo/bar:master-build-30
    asia.gcr.io/foo/bar:master-build-29
    asia.gcr.io/foo/bar:dev-build-124
    asia.gcr.io/foo/bar:dev-build-123
    asia.gcr.io/foo/bar:dev-build-122
    asia.gcr.io/foo/bar:dev-build-121
    asia.gcr.io/foo/bar:dev-build-120
    asia.gcr.io/foo/bar:dev-build-119
    asia.gcr.io/foo/bar:dev-build-113
    asia.gcr.io/foo/bar:dev-build-112
    asia.gcr.io/foo/bar:dev-build-111
    asia.gcr.io/foo/bar:dev-build-110
    ```

1. *What tags will be removed if I run 2 commands as below ?*

    ```sh
    $ go run main.go -repo asia.gcr.io/foo/bar -keep 2 -allow-tagged -tag-prefix staging
    asia.gcr.io/foo/bar:staging-build-62
    asia.gcr.io/foo/bar:staging-build-61
    asia.gcr.io/foo/bar:staging-build-60
    asia.gcr.io/foo/bar:staging-build-59
    asia.gcr.io/foo/bar:staging-build-58
    asia.gcr.io/foo/bar:staging-build-55
    asia.gcr.io/foo/bar:staging-build-54
    asia.gcr.io/foo/bar:staging-build-52

    $ go run main.go -repo asia.gcr.io/foo/bar -keep 2 -allow-tagged -tag-prefix dev
    remove asia.gcr.io/foo/bar:dev-build-122
    remove asia.gcr.io/foo/bar:dev-build-121
    remove asia.gcr.io/foo/bar:dev-build-120
    remove asia.gcr.io/foo/bar:dev-build-119
    remove asia.gcr.io/foo/bar:dev-build-113
    remove asia.gcr.io/foo/bar:dev-build-112
    remove asia.gcr.io/foo/bar:dev-build-111
    remove asia.gcr.io/foo/bar:dev-build-110

    ```