### PR TITLE
Fixed shouldDelete function for mix of tag/no tag images

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -162,5 +162,5 @@ func (c *Cleaner) deleteOne(ref gcrname.Reference) error {
 // shouldDelete returns true if the manifest has no tags or allows deletion of tagged images
 // and is before the requested time.
 func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool, tagFilterRegexp *regexp.Regexp) bool {
-	return ((allowTag && tagFilterRegexp.MatchString(m.Tags[0])) || len(m.Tags) == 0) && m.Uploaded.UTC().Before(since)
+	return (len(m.Tags) == 0 || (allowTag && tagFilterRegexp.MatchString(m.Tags[0]))) && m.Uploaded.UTC().Before(since)
 }


### PR DESCRIPTION
I have a mixed image collection where images with no tags are placed next to the tagged images and that caused issues for the `shouldDelete` function because MatchString attempted to grab value from empty `Tags` array on non-tagged image.
This complies with `allow_tagged` description in Readme and deletes both kind of images.