### PR TITLE
provide a flag to clean all repos in a registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ invoked periodically via [Cloud Scheduler][cloud-scheduler].
 The payload is expected to be JSON with the following fields:
 
 - `repo` - Full name of the repository to clean, in the format
-  `gcr.io/project/repo`. This field is required.
+  `gcr.io/project/repo`. Either this field is required or `registry`.
+
+- `registry` - Full name of the registry to clean in the format `gcr.io/project`.
+  This will clean ALL repos in a registry. Either this field is required or `repo`.
 
 - `grace` - Relative duration in which to ignore references. This value is
   specified as a time duration value like "5s" or "3h". If set, refs newer than


### PR DESCRIPTION
first off thanks for gcr-cleaner!  I love it!

I've made a little change on my fork to handle a `registry` so we can specify a top level container registry name, which will walk through ALL the repositories within it (we have a lot in our GCR)

i.e.
```
gcr-cleaner -registry gcr.io/foo
```

I wasn't sure on the name of the flag whether `registry` or `project` would have been better.  Anyways if this PR is useful then let me know of any changes you'd like me to make.

If you'd prefer not to handle a top level registry then that's ok too, just close the PR I wont be offended :)