### PR TITLE
Added the -recursive flag to load child repositories

### DIFF
--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -34,6 +34,7 @@ var (
 
 	tokenPtr       = flag.String("token", os.Getenv("GCRCLEANER_TOKEN"), "Authentication token")
 	repoPtr        = flag.String("repo", "", "Repository name")
+	recursivePtr   = flag.Bool("recursive", false, "Clean all sub-repositories under the -repo root")
 	gracePtr       = flag.Duration("grace", 0, "Grace period")
 	allowTaggedPtr = flag.Bool("allow-tagged", false, "Delete tagged images")
 	keepPtr        = flag.Int("keep", 0, "Minimum to keep")
@@ -89,13 +90,26 @@ func realMain() error {
 	}
 	since := time.Now().UTC().Add(sub)
 
-	// Do the deletion.
-	fmt.Fprintf(stdout, "%s: deleting refs since %s\n", *repoPtr, since)
-	deleted, err := cleaner.Clean(*repoPtr, since, *allowTaggedPtr, *keepPtr, tagFilterRegexp)
-	if err != nil {
-		return err
+	// Gather the repositories
+	var repositories = make([]string, 0)
+	repositories = append(repositories, *repoPtr)
+	if *recursivePtr {
+		childRepos, err := cleaner.ListChildRepositories(*repoPtr)
+		if err != nil {
+			return err
+		}
+		repositories = append(repositories, childRepos...)
 	}
-	fmt.Fprintf(stdout, "%s: successfully deleted %d refs", *repoPtr, len(deleted))
+
+	// Do the deletion.
+	for _, repo := range repositories {
+		fmt.Fprintf(stdout, "%s: deleting refs since %s\n", repo, since)
+		deleted, err := cleaner.Clean(repo, since, *allowTaggedPtr, *keepPtr, tagFilterRegexp)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(stdout, "%s: successfully deleted %d refs\n", repo, len(deleted))
+	}
 
 	return nil
 }

--- a/cmd/gcr-cleaner-cli/main.go
+++ b/cmd/gcr-cleaner-cli/main.go
@@ -104,7 +104,7 @@ func realMain() error {
 	}
 
 	// Do the deletion.
-	var result error
+	var result *multierror.Error
 	for _, repo := range repositories {
 		fmt.Fprintf(stdout, "%s: deleting refs since %s\n", repo, since)
 		deleted, err := cleaner.Clean(repo, since, *allowTaggedPtr, *keepPtr, tagFilterRegexp)
@@ -114,5 +114,5 @@ func realMain() error {
 		fmt.Fprintf(stdout, "%s: successfully deleted %d refs\n", repo, len(deleted))
 	}
 
-	return result
+	return result.ErrorOrNil()
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gammazero/deque v0.0.0-20201010052221-3932da5530cc // indirect
 	github.com/gammazero/workerpool v1.1.1
 	github.com/google/go-containerregistry v0.1.4
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20201029221708-28c70e62bb1d // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,10 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -167,8 +167,6 @@ func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowT
 }
 
 func (c *Cleaner) ListChildRepositories(ctx context.Context, rootRepository string) ([]string, error) {
-	var childRepos = make([]string, 0)
-
 	rootRepo, err := gcrname.NewRepository(rootRepository)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create repository %s: %w", rootRepository, err)
@@ -184,6 +182,7 @@ func (c *Cleaner) ListChildRepositories(ctx context.Context, rootRepository stri
 		return nil, fmt.Errorf("failed to fetch all repositories from registry %s: %w", registry.Name(), err)
 	}
 
+	var childRepos = make([]string, 0, len(allRepos))
 	for _, repo := range allRepos {
 		if strings.HasPrefix(repo, rootRepository) {
 			childRepos = append(childRepos, fmt.Sprintf("%s/%s", registry.Name(), repo))


### PR DESCRIPTION
Say I have a repository tree structure like the following:
```
gcr.io/myproject/garden/garlic
gcr.io/myproject/garden/onions
gcr.io/myproject/bike/mountain
```

I want to run gcr-cleaner against all repositories without explicitly running the command against each one. This is currently not possible.

With the addition of the `-recursive` flag in this PR, I am now able to do:

Clean all repositories in gcr.io/myproject
```
gcr-cleaner-cli -repo gcr.io/myproject -recursive
```

Or, clean all garden repositories:
```
gcr-cleaner-cli -repo gcr.io/myproject/garden -recursive
```