### PR TITLE
fix: Use go object to do correct comparision on child repos

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -184,7 +184,7 @@ func (c *Cleaner) ListChildRepositories(ctx context.Context, rootRepository stri
 
 	var childRepos = make([]string, 0, len(allRepos))
 	for _, repo := range allRepos {
-		if strings.HasPrefix(repo, rootRepository) {
+		if strings.HasPrefix(repo, rootRepo.RepositoryStr()) {
 			childRepos = append(childRepos, fmt.Sprintf("%s/%s", registry.Name(), repo))
 		}
 	}


### PR DESCRIPTION
`rootRepository` is a arg to the function and a string that has hostname
and path. Catalog() returns a slice of repositories, making the
HasPrefix check never work.

ref: #38