### PR TITLE
fix wrong deletion of len of tags is 0

### DIFF
--- a/pkg/gcrcleaner/cleaner.go
+++ b/pkg/gcrcleaner/cleaner.go
@@ -167,7 +167,7 @@ func (c *Cleaner) deleteOne(ref gcrname.Reference, dryRun bool) error {
 // shouldDelete returns true if the manifest has no tags or allows deletion of tagged images
 // and is before the requested time.
 func (c *Cleaner) shouldDelete(m gcrgoogle.ManifestInfo, since time.Time, allowTag bool, tagFilterRegexp *regexp.Regexp) bool {
-	return (len(m.Tags) == 0 || (allowTag && tagFilterRegexp.MatchString(m.Tags[0]))) && m.Uploaded.UTC().Before(since)
+	return len(m.Tags) > 0 && allowTag && tagFilterRegexp.MatchString(m.Tags[0]) && m.Uploaded.UTC().Before(since)
 }
 
 func (c *Cleaner) ListChildRepositories(ctx context.Context, rootRepository string) ([]string, error) {


### PR DESCRIPTION
I see there is a wrong deletion if the image have no tags( or length of tags = 0). 

Let's look at an example. Here's my tags on airflow-infra:

```
$  gcloud container images list-tags asia.gcr.io/projectname/airflow-infra
DIGEST        TAGS                      TIMESTAMP
ecab4edd6b40  1.10.12-python3.6,latest  2021-08-12T09:50:37
16985642c495                            2021-05-24T15:30:02
0f10ac5c8de4                            2021-05-05T12:17:20
622989b8201e                            2021-03-05T17:42:01
99808484165e  20210106-1                2021-01-06T12:47:08
08dabb6e723b                            2021-01-06T12:12:49
2c46b654b381                            2021-01-06T12:05:44
6373c00b6c06                            2021-01-05T16:30:34
05145c3b278b                            2021-01-05T16:19:57
21c938dfd8c7                            2021-01-05T16:04:30
845d48b52aae                            2020-12-28T10:46:55
d395dc02081e                            2020-12-21T17:23:28
fce159df4ba4                            2020-12-01T17:03:04
949486ee782f  10.10.10-deck-python3.6   2020-09-01T14:36:14

```

Let's try to  clean up by the command :

```
./gcrcleaner -dry-run -tag-filter "dev" -keep 5 -grace 240h -allow-tagged -repo asia.gcr.io/projectname/airflow-infra
```

**The expectation**
```
./gcrcleaner -dry-run -tag-filter "dev" -keep 5 -grace 240h -allow-tagged -repo asia.gcr.io/projectname/airflow-infra
WARNING: Running in dry run mode! Nothing will actually be cleaned.asia.gcr.io/projectname/airflow-infra: deleting refs since 2021-08-13 07:36:09.553540861 +0000 UTC
asia.gcr.io/projectname/airflow-infra: successfully deleted 0 refs
```

**But seems the script is trying to clean all untagged images**

```

$ ./gcrcleaner -dry-run -tag-filter "dev" -keep 5 -grace 240h -allow-tagged -repo asia.gcr.io/projectname/airflow-infra
WARNING: Running in dry run mode! Nothing will actually be cleaned.asia.gcr.io/projectname/airflow-infra: deleting refs since 2021-08-13 07:38:10.303900474 +0000 UTC
[dry-run] would delete: asia.gcr.io/projectname/airflow-infra@sha256:05145c3b278bed36efa9c86c58e10ee68cf8604caceaceb012efd8354dbedd83
[dry-run] would delete: asia.gcr.io/projectname/airflow-infra@sha256:d395dc02081e8d34af23134f0a3489c4c214f690a8a291e3f2d4a76e891c65be
[dry-run] would delete: asia.gcr.io/projectname/airflow-infra@sha256:845d48b52aae9f7ae553e7320115394c73b0bd25f9cad05e13c767d0a714705d
[dry-run] would delete: asia.gcr.io/projectname/airflow-infra@sha256:6373c00b6c06f03dee4e7767968042d51871a16011e9e7ad6a87747b757b28ce
[dry-run] would delete: asia.gcr.io/projectname/airflow-infra@sha256:21c938dfd8c7c494de915156c74d3f706cb32307c441a44d50b5633738ca152d
[dry-run] would delete: asia.gcr.io/projectname/airflow-infra@sha256:fce159df4ba47e4a360abde3441a14500616edcae41e08435172efc3bce785ab
asia.gcr.io/projectname/airflow-infra: successfully deleted 6 refs

```
